### PR TITLE
Shine5402OtoToolbox v0.5.1

### DIFF
--- a/i18n/shine5402ototoolbox_en.ts
+++ b/i18n/shine5402ototoolbox_en.ts
@@ -1202,37 +1202,37 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="216"/>
         <source>以下显示了根据您的要求要对 %1（位于第 %2 项）执行的修改。</source>
-        <translation type="unfinished"></translation>
+        <translation>These are changes that will be applied to %1 （at %2). Click &quot;OK&quot; to confirm, &quot;Cancel&quot; to discard these changes.</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="230"/>
         <source>保存时出现错误</source>
-        <translation type="unfinished"></translation>
+        <translation>Error occured while saving</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="230"/>
         <source>无法保存 %1（位于第 %2 项），操作终止，该项之前的项已被保存。</source>
-        <translation type="unfinished"></translation>
+        <translation>As %1 (at %2) can not be saved, the process is stopped. Files before it has been saved.</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="291"/>
         <source>保存失败</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="294"/>
         <source>在保存 %1 时发生错误。</source>
-        <translation type="unfinished"></translation>
+        <translation>Error occured when saving %1.</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="296"/>
         <source>该文件的用途是 %1。</source>
-        <translation type="unfinished"></translation>
+        <translation>The file is meant to be used for %1.</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="297"/>
         <source>遇到的错误是：%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error information: %1</translation>
     </message>
 </context>
 <context>
@@ -1240,22 +1240,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="60"/>
         <source>文件未加载</source>
-        <translation type="unfinished"></translation>
+        <translation>File is not loaded</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="60"/>
         <source>您还没有加载oto.ini文件。请加载后重试。</source>
-        <translation type="unfinished"></translation>
+        <translation>No oto files has been loaded. Please load them and retry.</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="76"/>
         <source>操作成功完成</source>
-        <translation type="unfinished"></translation>
+        <translation>Processes are completed successfully</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialog.cpp" line="76"/>
         <source>操作成功完成。</source>
-        <translation type="unfinished"></translation>
+        <translation>Processes are completed successfully.</translation>
     </message>
 </context>
 <context>
@@ -1263,12 +1263,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../src/toolBase/tooldialogadapter.cpp" line="33"/>
         <source>确认更改</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm modifications</translation>
     </message>
     <message>
         <location filename="../src/toolBase/tooldialogadapter.cpp" line="34"/>
         <source>以下显示了根据您的要求要对原音设定数据执行的修改。点击“确定”来确认此修改，点击“取消”以取消本次操作。</source>
-        <translation type="unfinished"></translation>
+        <translation>These are changes that will be applied to oto data. Click &quot;OK&quot; to confirm, &quot;Cancel&quot; to discard these changes.</translation>
     </message>
 </context>
 </TS>

--- a/src/RemoveAffix/removeaffixdialogadapter.cpp
+++ b/src/RemoveAffix/removeaffixdialogadapter.cpp
@@ -4,12 +4,11 @@
 
 RemoveAffixDialogAdapter::RemoveAffixDialogAdapter(QObject* parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new RemoveAffixOtoListModifyWorker(this));
-    setOptionWidget(new RemoveAffixOptionWidget);
+    setWorkerMetaObj(RemoveAffixOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(RemoveAffixOptionWidget::staticMetaObject);
 }
 
 QString RemoveAffixDialogAdapter::getToolName() const
 {
     return tr("去除别名前/后缀");
 }
-

--- a/src/addAffix/addaffixdialogadapter.cpp
+++ b/src/addAffix/addaffixdialogadapter.cpp
@@ -4,8 +4,8 @@
 
 AddAffixDialogAdapter::AddAffixDialogAdapter(QObject* parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new AddAffixOtoListModifyWorker(this));
-    setOptionWidget(new AddAffixOptionWidget);
+    setWorkerMetaObj(AddAffixOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(AddAffixOptionWidget::staticMetaObject);
 }
 
 

--- a/src/chain/chaindialogadapter.cpp
+++ b/src/chain/chaindialogadapter.cpp
@@ -4,8 +4,8 @@
 
 ChainDialogAdapter::ChainDialogAdapter(QObject* parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new ChainOtoListModifyWorker(this));
-    setOptionWidget(new ChainToolOptionWidget);
+    setWorkerMetaObj(ChainOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(ChainToolOptionWidget::staticMetaObject);
 }
 
 QString ChainDialogAdapter::getToolName() const

--- a/src/chain/chainelement.h
+++ b/src/chain/chainelement.h
@@ -1,29 +1,8 @@
 #ifndef CHAINELEMENT_H
 #define CHAINELEMENT_H
 
-#include <QMetaObject>
-#include <toolBase/optioncontainer.h>
-#include <memory>
-#include <toolBase/tooldialogadapter.h>
+#include <toolBase/toolmanager.h>
 
-struct ChainElement
-{
-   QMetaObject toolAdapterMetaObj;
-   QMetaObject toolModifyWorkerMetaObj;
-   QMetaObject toolOptionWidgetMetaObj;
-   OptionContainer options;
-
-   QString toolName() const{
-       if (auto toolAdapter = std::unique_ptr<ToolDialogAdapter>(
-                   qobject_cast<ToolDialogAdapter *>(
-                       toolAdapterMetaObj.newInstance()
-                       ))){
-           return toolAdapter->getToolName();
-       }
-       return {};
-   }
-};
-
-Q_DECLARE_METATYPE(ChainElement)
+using ChainElement = ToolWithOptions;
 
 #endif // CHAINELEMENT_H

--- a/src/chain/chainelement.h
+++ b/src/chain/chainelement.h
@@ -1,0 +1,29 @@
+#ifndef CHAINELEMENT_H
+#define CHAINELEMENT_H
+
+#include <QMetaObject>
+#include <toolBase/optioncontainer.h>
+#include <memory>
+#include <toolBase/tooldialogadapter.h>
+
+struct ChainElement
+{
+   QMetaObject toolAdapterMetaObj;
+   QMetaObject toolModifyWorkerMetaObj;
+   QMetaObject toolOptionWidgetMetaObj;
+   OptionContainer options;
+
+   QString toolName() const{
+       if (auto toolAdapter = std::unique_ptr<ToolDialogAdapter>(
+                   qobject_cast<ToolDialogAdapter *>(
+                       toolAdapterMetaObj.newInstance()
+                       ))){
+           return toolAdapter->getToolName();
+       }
+       return {};
+   }
+};
+
+Q_DECLARE_METATYPE(ChainElement)
+
+#endif // CHAINELEMENT_H

--- a/src/chain/chainotolistmodifyworker.cpp
+++ b/src/chain/chainotolistmodifyworker.cpp
@@ -18,10 +18,7 @@ bool ChainOtoListModifyWorker::doWork(const OtoEntryList& srcOtoList, OtoEntryLi
 
     for (const auto& step : steps){
         auto stepOption = step.options;
-        success |= std::unique_ptr<OtoListModifyWorker>(
-                    qobject_cast<OtoListModifyWorker *>(
-                        step.toolModifyWorkerMetaObj.newInstance()
-                        ))->doWork(lastResult, currentResult, secondSaveOtoList, stepOption);
+        success |= step.tool.getWorkerInstance()->doWork(lastResult, currentResult, secondSaveOtoList, stepOption);
 
         lastResult = std::move(currentResult);
         currentResult = {};

--- a/src/chain/chainotolistmodifyworker.cpp
+++ b/src/chain/chainotolistmodifyworker.cpp
@@ -1,5 +1,6 @@
 #include "chainotolistmodifyworker.h"
 #include "toolBase/toolmanager.h"
+#include "chainelement.h"
 
 ChainOtoListModifyWorker::ChainOtoListModifyWorker(QObject* parent) : OtoListModifyWorker(parent)
 {
@@ -13,11 +14,14 @@ bool ChainOtoListModifyWorker::doWork(const OtoEntryList& srcOtoList, OtoEntryLi
 
     bool success = false;
 
-    auto steps = options.getOption("steps").value<QVector<Tool>>();
+    auto steps = options.getOption("steps").value<QVector<ChainElement>>();
 
-    for (auto step : steps){
-        auto stepOption = step.getOptionWidget()->getOptions();
-        success |= step.getModifyWorker()->doWork(lastResult, currentResult, secondSaveOtoList, stepOption);
+    for (const auto& step : steps){
+        auto stepOption = step.options;
+        success |= std::unique_ptr<OtoListModifyWorker>(
+                    qobject_cast<OtoListModifyWorker *>(
+                        step.toolModifyWorkerMetaObj.newInstance()
+                        ))->doWork(lastResult, currentResult, secondSaveOtoList, stepOption);
 
         lastResult = std::move(currentResult);
         currentResult = {};

--- a/src/chain/chainstepsmodel.cpp
+++ b/src/chain/chainstepsmodel.cpp
@@ -1,6 +1,7 @@
 #include "chainstepsmodel.h"
+#include "toolBase/tooldialogadapter.h"
 
-ChainStepsModel::ChainStepsModel(const QVector<Tool>& steps, QObject *parent)
+ChainStepsModel::ChainStepsModel(const QVector<ChainElement>& steps, QObject *parent)
     : QAbstractListModel(parent), steps(steps)
 {
 }
@@ -22,8 +23,9 @@ QVariant ChainStepsModel::data(const QModelIndex &index, int role) const
 
     if (role == Qt::DisplayRole)
     {
-        if (index.row() < steps.count())
-            return steps.at(index.row()).getName();
+        if (index.row() < steps.count()){
+            return steps.at(index.row()).toolName();
+        }
     }
     return QVariant();
 }
@@ -33,7 +35,7 @@ int ChainStepsModel::stepCount() const
     return steps.count();
 }
 
-void ChainStepsModel::addStep(const Tool& step)
+void ChainStepsModel::addStep(const ChainElement& step)
 {
     beginInsertRows(QModelIndex{}, steps.count(), steps.count());
     steps.append(step);
@@ -65,17 +67,27 @@ void ChainStepsModel::moveDownStep(int index)
     }
 }
 
-const Tool& ChainStepsModel::getStep(int index) const
+const ChainElement& ChainStepsModel::getStep(int index) const
 {
     return steps.at(index);
 }
 
-QVector<Tool> ChainStepsModel::getSteps() const
+void ChainStepsModel::setStep(int index, const ChainElement& value)
+{
+    steps[index] = value;
+}
+
+void ChainStepsModel::setStepOptions(int index, const OptionContainer& value)
+{
+    steps[index].options = value;
+}
+
+QVector<ChainElement> ChainStepsModel::getSteps() const
 {
     return steps;
 }
 
-void ChainStepsModel::setSteps(const QVector<Tool>& value)
+void ChainStepsModel::setSteps(const QVector<ChainElement>& value)
 {
     beginResetModel();
     steps = value;

--- a/src/chain/chainstepsmodel.h
+++ b/src/chain/chainstepsmodel.h
@@ -2,14 +2,14 @@
 #define CHAINSTEPSMODEL_H
 
 #include <QAbstractListModel>
-#include "toolBase/toolmanager.h"
+#include "chainelement.h"
 
 class ChainStepsModel : public QAbstractListModel
 {
     Q_OBJECT
 
 public:
-    explicit ChainStepsModel(const QVector<Tool>& steps = {}, QObject *parent = nullptr);
+    explicit ChainStepsModel(const QVector<ChainElement>& steps = {}, QObject *parent = nullptr);
 
     // Basic functionality:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -17,20 +17,22 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     int stepCount() const;
-    void addStep(const Tool& step);
+    void addStep(const ChainElement& step);
     void removeStep(int index);
     void moveUpStep(int index);
     void moveDownStep(int index);
-    const Tool& getStep(int index) const;
+    const ChainElement& getStep(int index) const;
+    void setStep(int index, const ChainElement& value);
+    void setStepOptions(int index, const OptionContainer& value);
 
-    QVector<Tool> getSteps() const;
+    QVector<ChainElement> getSteps() const;
 
-    void setSteps(const QVector<Tool>& value);
+    void setSteps(const QVector<ChainElement>& value);
 
 public slots:
 
 private:
-    QVector<Tool> steps;
+    QVector<ChainElement> steps;
 };
 
 #endif // CHAINSTEPSMODEL_H

--- a/src/chain/chaintooloptionwidget.cpp
+++ b/src/chain/chaintooloptionwidget.cpp
@@ -57,7 +57,7 @@ void ChainToolOptionWidget::addStep()
 {
     auto registeredTools = ToolManager::getManager()->getTools();
     auto availableTools = fplus::transform([](Tool tool)->ChainElement{
-            return {*tool.getDialogAdapter()->metaObject(), *tool.getModifyWorker()->metaObject(), *tool.getOptionWidget()->metaObject(), {}};
+            return {tool, {}};
     }, registeredTools);
     auto model = new ChainStepsModel(availableTools, this);
     auto dialog = new ListViewDialog(this, model, tr("选择一个工具"), tr("从下面的可用工具中选择一个作为操作文件的新步骤。"), QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -107,7 +107,7 @@ void ChainToolOptionWidget::openStepSettings(int index)
     dialogLayout->setStretch(GROUPBOX_INDEX, GROUPBOX_STRETCH);//让GroupBox的权重变大
 
     auto groupBoxLayout = new QVBoxLayout(groupBox);
-    auto optionWidget = qobject_cast<ToolOptionWidget *>(stepsModel->getStep(index).toolOptionWidgetMetaObj.newInstance(Q_ARG(QWidget*, this)));
+    auto optionWidget = stepsModel->getStep(index).tool.getToolOptionWidgetInstance(this);
     optionWidget->setOptions(stepsModel->getStep(index).options);
     groupBoxLayout->addWidget(optionWidget);
     groupBox->setLayout(groupBoxLayout);

--- a/src/chain/chaintooloptionwidget.h
+++ b/src/chain/chaintooloptionwidget.h
@@ -18,6 +18,7 @@ class ChainToolOptionWidget : public ToolOptionWidget
 public:
     Q_INVOKABLE explicit ChainToolOptionWidget(QWidget *parent = nullptr);
     ~ChainToolOptionWidget();
+
     OptionContainer getOptions() const override;
     void setOptions(const OptionContainer &options) override;
 
@@ -29,6 +30,12 @@ private:
     void setCurrentRow(int row);
 
     void openStepSettings(int index);
+    struct stepSettingsDialogInfo{
+        stepSettingsDialogInfo() : ptrDialog(nullptr), ptrOptionWidget(nullptr), index(-1){};
+        QDialog* ptrDialog;
+        ToolOptionWidget* ptrOptionWidget;
+        int index;
+    } pendingStepSetting;
     
 private slots:
     void addStep();
@@ -36,6 +43,7 @@ private slots:
     void moveUpCurrentStep();
     void moveDownCurrentStep();
     void openStepSettings();
+    void handleStepSettingsDone(int result);
 
 };
 

--- a/src/cv_vcPartSplit/cv_vcpartsplitoptionwidget.h
+++ b/src/cv_vcPartSplit/cv_vcpartsplitoptionwidget.h
@@ -13,7 +13,7 @@ class CV_VCPartSplitOptionWidget : public ToolOptionWidget
     Q_OBJECT
 
 public:
-    explicit CV_VCPartSplitOptionWidget(QWidget *parent = nullptr);
+    Q_INVOKABLE explicit CV_VCPartSplitOptionWidget(QWidget *parent = nullptr);
     ~CV_VCPartSplitOptionWidget();
 
 private:

--- a/src/cv_vcPartSplit/cv_vcpartsplitotolistmodifyworker.h
+++ b/src/cv_vcPartSplit/cv_vcpartsplitotolistmodifyworker.h
@@ -7,7 +7,7 @@ class CV_VCPartSplitOtoListModifyWorker : public OtoListModifyWorker
 {
     Q_OBJECT
 public:
-    explicit CV_VCPartSplitOtoListModifyWorker(QObject *parent = nullptr);
+    Q_INVOKABLE explicit CV_VCPartSplitOtoListModifyWorker(QObject *parent = nullptr);
 
     // OtoListModifyWorker interface
 public:

--- a/src/cv_vcPartSplit/cv_vcpartsplittooldialogadapter.cpp
+++ b/src/cv_vcPartSplit/cv_vcpartsplittooldialogadapter.cpp
@@ -6,6 +6,7 @@
 CV_VCPartSplitToolDialogAdapter::CV_VCPartSplitToolDialogAdapter(QObject *parent) : ToolDialogAdapter(parent)
 {
     setWorker(new CV_VCPartSplitOtoListModifyWorker(this));
+    setOptionWidget(new CV_VCPartSplitOptionWidget);
 }
 
 void CV_VCPartSplitToolDialogAdapter::replaceUIWidgets(QLayout* rootLayout)
@@ -14,9 +15,7 @@ void CV_VCPartSplitToolDialogAdapter::replaceUIWidgets(QLayout* rootLayout)
     saveWidget->setSecondFileNameCheckBoxText("分离VC部到新文件：");
     saveWidget->setSecondFileNameUsage("保存分离出来的VC部");
     replaceSaveWidget(rootLayout, saveWidget);
-    auto optionWidget = new CV_VCPartSplitOptionWidget;
-    optionWidget->setOptions(OptionContainer{});
-    replaceOptionWidget(rootLayout, optionWidget);
+    ToolDialogAdapter::replaceUIWidgets(rootLayout);
 }
 
 QString CV_VCPartSplitToolDialogAdapter::getToolName() const

--- a/src/cv_vcPartSplit/cv_vcpartsplittooldialogadapter.cpp
+++ b/src/cv_vcPartSplit/cv_vcpartsplittooldialogadapter.cpp
@@ -5,8 +5,8 @@
 
 CV_VCPartSplitToolDialogAdapter::CV_VCPartSplitToolDialogAdapter(QObject *parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new CV_VCPartSplitOtoListModifyWorker(this));
-    setOptionWidget(new CV_VCPartSplitOptionWidget);
+    setWorkerMetaObj(CV_VCPartSplitOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(CV_VCPartSplitOptionWidget::staticMetaObject);
 }
 
 void CV_VCPartSplitToolDialogAdapter::replaceUIWidgets(QLayout* rootLayout)
@@ -25,7 +25,6 @@ QString CV_VCPartSplitToolDialogAdapter::getToolName() const
 
 bool CV_VCPartSplitToolDialogAdapter::doWork(const OtoEntryList& srcOtoList, OtoEntryList& resultOtoList, OtoEntryList& secondSaveOtoList, const OptionContainer& options, QWidget* dialogParent)
 {
-    Q_ASSERT_X(getWorker(), "doWorkAdapter", "Worker is not set.");
     auto precision = options.getOption("save/precision").toInt();
     auto isSecondFileNameUsed = options.getOption("save/isSecondFileNameUsed").toBool();
     if (ToolDialogAdapter::doWork(srcOtoList, resultOtoList, secondSaveOtoList, options)){

--- a/src/cv_vcPartSplit/cv_vcpartsplittooldialogadapter.h
+++ b/src/cv_vcPartSplit/cv_vcpartsplittooldialogadapter.h
@@ -7,7 +7,7 @@ class CV_VCPartSplitToolDialogAdapter : public ToolDialogAdapter
 {
     Q_OBJECT
 public:
-    explicit CV_VCPartSplitToolDialogAdapter(QObject *parent = nullptr);
+    Q_INVOKABLE explicit CV_VCPartSplitToolDialogAdapter(QObject *parent = nullptr);
 
     // ToolDialogAdapter interface
 public:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -42,7 +42,7 @@ MainWindow::MainWindow(QWidget *parent)
         std::reverse(tools.begin(), tools.end());
         for (const auto& tool : tools)
         {
-            auto button = new QPushButton(tool.getName(), this);
+            auto button = new QPushButton(tool.toolName(), this);
             buttonGroup->addButton(button, availableTools.indexOf(tool));
             groupBoxLayout->addWidget(button);
         }
@@ -51,7 +51,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     connect(buttonGroup, QOverload<QAbstractButton *>::of(&QButtonGroup::buttonClicked), [buttonGroup, this](QAbstractButton* button){
         auto tools = ToolManager::getManager()->getTools();
-        (new ToolDialog(tools.at(buttonGroup->id(button)).getDialogAdapter(), this))->open();
+        (new ToolDialog(tools.at(buttonGroup->id(button)).getAdapterInstance(this), this))->open();
     });
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -68,24 +68,27 @@ void MainWindow::exit()
 
 void MainWindow::showAboutDialog()
 {
-    QMessageBox::about(this, tr("关于"), tr(R"(<h2>shine_5402 的 oto 工具箱</h2>
+    QMessageBox::about(this, tr("关于"), tr(
+R"(<h2>shine_5402 的 oto 工具箱</h2>
 
-                                                <p>Copyright 2020 <a href="https://shine5402.top/about-me">shine_5402</a></p>
-                                                <p>版本 %1</p>
-                                                <h3>关于</h3>
-                                                <p>一个个人自用向的操作UTAU用声音资料库的原音设定文件oto.ini的工具箱</p>
-                                                <h3>许可</h3>
-                                                <p>本程序是自由软件：你可以在遵守由自由软件基金会发布的GNU通用公共许可证版本3（或者更新的版本）的情况下重新分发和/或修改本程序。</p>
-                                                <p>本程序的发布旨在能够派上用场，但是<span style="font-weight: bold;">并不对此作出任何担保</span>；乃至也没有对<span style="font-weight: bold;">适销性</span>或<span style="font-weight: bold;">特定用途适用性</span>的默示担保。参见GNU通用公共许可证来获得更多细节。</p>
-                                                <p>在得到本程序的同时，您应该也收到了一份GNU通用公共许可证的副本。如果没有，请查阅<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>。</p>
+<p>Copyright 2020 <a href="https://shine5402.top/about-me">shine_5402</a></p>
+<p>版本 %1</p>
+<h3>关于</h3>
+<p>一个个人自用向的操作UTAU用声音资料库的原音设定文件oto.ini的工具箱</p>
+<h3>许可</h3>
+<p>本程序是自由软件：你可以在遵守由自由软件基金会发布的GNU通用公共许可证版本3（或者更新的版本）的情况下重新分发和/或修改本程序。</p>
+<p>本程序的发布旨在能够派上用场，但是<span style="font-weight: bold;">并不对此作出任何担保</span>；乃至也没有对<span style="font-weight: bold;">适销性</span>或<span style="font-weight: bold;">特定用途适用性</span>的默示担保。参见GNU通用公共许可证来获得更多细节。</p>
+<p>在得到本程序的同时，您应该也收到了一份GNU通用公共许可证的副本。如果没有，请查阅<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>。</p>
 
-                                                <h3>本程序使用的开源软件库</h3>
-                                                <ul>
-                                                <li>Qt, The Qt Company Ltd, under LGPL v3.</li>
-                                                <li>QKiraUTAUUtils, shine_5402, under LGPL v3</li>
-                                                <li><a href="https://github.com/google/diff-match-patch">Diff-Match-Patch</a>, Copyright 2018 The diff-match-patch Authors, under the Apache License, Version 2.0</li>
-                                                </ul>
-                                                )").arg(qApp->applicationVersion()));
+<h3>本程序使用的开源软件库</h3>
+<ul>
+<li>Qt, The Qt Company Ltd, under LGPL v3.</li>
+<li>QKiraUTAUUtils, shine_5402, under LGPL v3</li>
+<li><a href="https://github.com/google/diff-match-patch">Diff-Match-Patch</a>, Copyright 2018 The diff-match-patch Authors, under the Apache License, Version 2.0</li>
+<li><a href="https://github.com/Dobiasd/FunctionalPlus">FunctionalPlus</a>, BSL-1.0 License</li>
+</ul>
+)"
+).arg(qApp->applicationVersion()));
 }
 
 void MainWindow::showAboutQtDialog()

--- a/src/notdoanything/notdoanythingdialogadapter.cpp
+++ b/src/notdoanything/notdoanythingdialogadapter.cpp
@@ -4,8 +4,8 @@
 
 NotDoAnythingDialogAdapter::NotDoAnythingDialogAdapter(QObject *parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new NotDoAnythingOtoListModifyWorker(this));
-    setOptionWidget(new NotDoAnythingOptionWidget);
+    setWorkerMetaObj(NotDoAnythingOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(NotDoAnythingOptionWidget::staticMetaObject);
 }
 
 QString NotDoAnythingDialogAdapter::getToolName() const

--- a/src/notdoanything/notdoanythingoptionwidget.cpp
+++ b/src/notdoanything/notdoanythingoptionwidget.cpp
@@ -15,7 +15,7 @@ NotDoAnythingOptionWidget::NotDoAnythingOptionWidget(QWidget *parent) : ToolOpti
 
 OptionContainer NotDoAnythingOptionWidget::getOptions() const
 {
-    return OptionContainer{};
+    return {};
 }
 
 void NotDoAnythingOptionWidget::setOptions(const OptionContainer& options)

--- a/src/overlapBatchSet/overlapbatchsetdialogadapter.cpp
+++ b/src/overlapBatchSet/overlapbatchsetdialogadapter.cpp
@@ -7,8 +7,8 @@
 
 OverlapBatchSetDialogAdapter::OverlapBatchSetDialogAdapter(QObject* parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new OverlapBatchSetOtoListModifyWorker(this));
-    setOptionWidget(new OverlapBatchSetDialogOptionWidget);
+    setWorkerMetaObj(OverlapBatchSetOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(OverlapBatchSetDialogOptionWidget::staticMetaObject);
 }
 
 QString OverlapBatchSetDialogAdapter::getToolName() const

--- a/src/registerTools.cpp
+++ b/src/registerTools.cpp
@@ -11,22 +11,21 @@
 #include "cv_vcPartSplit/cv_vcpartsplittooldialogadapter.h"
 #include <QCoreApplication>
 
-//TODO:重构为临时建立新工具实例
 void registerTools()
 {
     auto manager = ToolManager::getManager();
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "去除不需要的项"), new RemoveDuplicateDialogAdapter);
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "去除不需要的项"), new RemoveBlankDialogAdapter);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "去除不需要的项"), RemoveDuplicateDialogAdapter::staticMetaObject);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "去除不需要的项"), RemoveBlankDialogAdapter::staticMetaObject);
 
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "批量设置数值"), new OverlapBatchSetDialogAdapter);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "批量设置数值"), OverlapBatchSetDialogAdapter::staticMetaObject);
 
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "对别名进行操作"), new RemoveAffixDialogAdapter);
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "对别名进行操作"), new AddAffixDialogAdapter);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "对别名进行操作"), RemoveAffixDialogAdapter::staticMetaObject);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "对别名进行操作"), AddAffixDialogAdapter::staticMetaObject);
 
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "筛选出需要的项"), new CV_VCPartSplitToolDialogAdapter);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "筛选出需要的项"), CV_VCPartSplitToolDialogAdapter::staticMetaObject);
 
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "元操作"), new ChainDialogAdapter);
-    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "元操作"), new NotDoAnythingDialogAdapter);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "元操作"), ChainDialogAdapter::staticMetaObject);
+    manager->registerTool(QCoreApplication::translate("TOOL_TYPE", "元操作"), NotDoAnythingDialogAdapter::staticMetaObject);
 }
 
 //TODO:合并oto.ini文件

--- a/src/registerTools.cpp
+++ b/src/registerTools.cpp
@@ -11,6 +11,7 @@
 #include "cv_vcPartSplit/cv_vcpartsplittooldialogadapter.h"
 #include <QCoreApplication>
 
+//TODO:重构为临时建立新工具实例
 void registerTools()
 {
     auto manager = ToolManager::getManager();

--- a/src/removeBlank/removeblankdialogadapter.cpp
+++ b/src/removeBlank/removeblankdialogadapter.cpp
@@ -4,11 +4,12 @@
 
 RemoveBlankDialogAdapter::RemoveBlankDialogAdapter(QObject* parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new RemoveBlankOtoListModifyWorker(this));
-    setOptionWidget(new RemoveBlankOptionWidget);
+    setWorkerMetaObj(RemoveBlankOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(RemoveBlankOptionWidget::staticMetaObject);
 }
 
 QString RemoveBlankDialogAdapter::getToolName() const
 {
     return tr("清除空白项");
 }
+

--- a/src/removeDuplicate/removeduplicatedialogadapter.cpp
+++ b/src/removeDuplicate/removeduplicatedialogadapter.cpp
@@ -14,8 +14,8 @@
 
 RemoveDuplicateDialogAdapter::RemoveDuplicateDialogAdapter(QObject* parent) : ToolDialogAdapter(parent)
 {
-    setWorker(new RemoveDuplicateModuleOtoListModifyWorker(this));
-    setOptionWidget(new RemoveDuplicateDialogOptionWidget);
+    setWorkerMetaObj(RemoveDuplicateModuleOtoListModifyWorker::staticMetaObject);
+    setOptionWidgetMetaObj(RemoveDuplicateDialogOptionWidget::staticMetaObject);
 }
 
 void RemoveDuplicateDialogAdapter::replaceUIWidgets(QLayout* rootLayout)
@@ -29,7 +29,7 @@ bool RemoveDuplicateDialogAdapter::doWork(const OtoEntryList& srcOtoList, OtoEnt
     auto precision = options.getOption("save/precision").toInt();
     if (ToolDialogAdapter::doWork(srcOtoList, resultOtoList, secondSaveOtoList, options))
     {
-        auto specificWorker = static_cast<RemoveDuplicateModuleOtoListModifyWorker*>(getWorker());
+        auto specificWorker = new RemoveDuplicateModuleOtoListModifyWorker(this);
         if ((!specificWorker->getOrganizeResult().isEmpty()) &&
                 (!Misc::showOtoDiffDialog(srcOtoList, specificWorker->getOrganizeResult(), precision, tr("重复项整理结果"),
                                          tr("以下特别标出的原音设定的别名将会被重命名，其中多余的重复项将根据您的设置在下一步被删除。点击“确定”来确认此修改，点击“取消”以取消本次操作。"),

--- a/src/removeDuplicate/removeduplicatedialogoptionwidget.h
+++ b/src/removeDuplicate/removeduplicatedialogoptionwidget.h
@@ -31,7 +31,7 @@ class RemoveDuplicateDialogOptionWidget : public ToolOptionWidget
     Q_OBJECT
 
 public:
-    explicit RemoveDuplicateDialogOptionWidget(QWidget *parent = nullptr);
+    Q_INVOKABLE explicit RemoveDuplicateDialogOptionWidget(QWidget *parent = nullptr);
     ~RemoveDuplicateDialogOptionWidget();
     OptionContainer getOptions() const override;
     void setOptions(const OptionContainer& options) override;

--- a/src/src.pro
+++ b/src/src.pro
@@ -6,7 +6,7 @@ CONFIG += c++17
 
 TARGET = Shine5402OtoToolBox
 
-VERSION = 0.4.0
+VERSION = 0.5.0
 
 RC_ICONS = resources/icon/appIcon.ico
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -6,7 +6,7 @@ CONFIG += c++17
 
 TARGET = Shine5402OtoToolBox
 
-VERSION = 0.5.0
+VERSION = 0.5.1
 
 RC_ICONS = resources/icon/appIcon.ico
 
@@ -83,6 +83,7 @@ SOURCES += \
 
 HEADERS += \
     chain/chaindialogadapter.h \
+    chain/chainelement.h \
     chain/chainotolistmodifyworker.h \
     chain/chainstepsmodel.h \
     chain/chaintooloptionwidget.h \

--- a/src/toolBase/optioncontainer.h
+++ b/src/toolBase/optioncontainer.h
@@ -9,7 +9,8 @@ class OptionContainer : public QObject {
     Q_OBJECT
 
 public:
-    explicit OptionContainer(QObject* parent = nullptr) : QObject(parent){};
+    OptionContainer():QObject(nullptr){};
+    explicit OptionContainer(QObject* parent) : QObject(parent){};
     QVariant getOption(const QString& key, const QVariant& defaultValue = {}, bool* matched = nullptr) const;
     void setOption(const QString& key, const QVariant& value, bool* replaced = nullptr);
     bool removeOption(const QString& key);

--- a/src/toolBase/tooldialog.cpp
+++ b/src/toolBase/tooldialog.cpp
@@ -63,8 +63,6 @@ void ToolDialog::ToolDialog::accept()
 
     bool success = false;
     if (isSingleMode()){
-        qDebug() << ui->optionWidget;
-        qDebug() << ui->otoSaveWidget;
         success = doWork(ui->otoLoadWidget->getEntryList(), ui->otoLoadWidget->fileName(), OptionContainer::combine(ui->optionWidget->getOptions(), ui->otoSaveWidget->getOptions(), "save/"), this);
     }
     else {
@@ -96,6 +94,7 @@ void ToolDialog::resetOto()
 void ToolDialog::resetOptions()
 {
     ui->optionWidget->setOptions(OptionContainer{});
+    ui->otoSaveWidget->setOptions(OptionContainer{});
 }
 
 void ToolDialog::buttonBoxClicked(QAbstractButton* button)

--- a/src/toolBase/tooldialog.cpp
+++ b/src/toolBase/tooldialog.cpp
@@ -93,8 +93,8 @@ void ToolDialog::resetOto()
 
 void ToolDialog::resetOptions()
 {
-    ui->optionWidget->setOptions(OptionContainer{});
-    ui->otoSaveWidget->setOptions(OptionContainer{});
+    ui->optionWidget->setOptions({});
+    ui->otoSaveWidget->setOptions({});
 }
 
 void ToolDialog::buttonBoxClicked(QAbstractButton* button)

--- a/src/toolBase/tooldialogadapter.cpp
+++ b/src/toolBase/tooldialogadapter.cpp
@@ -18,15 +18,13 @@ ToolDialogAdapter::ToolDialogAdapter(QObject *parent) : QObject(parent)
 
 void ToolDialogAdapter::replaceUIWidgets(QLayout* rootLayout)
 {
-    Q_ASSERT_X(optionWidget, "setupSpecificUIWidgets", "OptionWidget is not set.");
-    optionWidget->setOptions({});
-    optionWidget->setParent(rootLayout->parentWidget());
+    Q_ASSERT_X(optionWidgetMetaObj.inherits(&ToolOptionWidget::staticMetaObject), "setupSpecificUIWidgets", "OptionWidget is not set.");
+    auto optionWidget = qobject_cast<ToolOptionWidget *>(optionWidgetMetaObj.newInstance(Q_ARG(QWidget*, rootLayout->parentWidget())));
     replaceOptionWidget(rootLayout, optionWidget);
 }
 
 bool ToolDialogAdapter::doWork(const OtoEntryList& srcOtoList, OtoEntryList& resultOtoList, OtoEntryList& secondSaveOtoList, const OptionContainer& options, QWidget* dialogParent)
 {
-    Q_ASSERT_X(getWorker(), "doWorkAdapter", "Worker is not set.");
     auto precision = options.getOption("save/precision").toInt();
     if (doWork(srcOtoList, resultOtoList, secondSaveOtoList, options))
         return Misc::showOtoDiffDialog(srcOtoList, resultOtoList, precision,
@@ -38,34 +36,44 @@ bool ToolDialogAdapter::doWork(const OtoEntryList& srcOtoList, OtoEntryList& res
 
 bool ToolDialogAdapter::doWork(const OtoEntryList& srcOtoList, OtoEntryList& resultOtoList, OtoEntryList& secondSaveOtoList, const OptionContainer& options)
 {
-    Q_ASSERT_X(getWorker(), "doWorkAdapter", "Worker is not set.");
-    return getWorker()->doWork(srcOtoList, resultOtoList, secondSaveOtoList, options);
+    Q_ASSERT_X(workerMetaObj.inherits(&OtoListModifyWorker::staticMetaObject), "doWorkAdapter", "Worker is not set.");
+    auto worker = qobject_cast<OtoListModifyWorker *>(workerMetaObj.newInstance(Q_ARG(QObject*, this)));
+    return worker->doWork(srcOtoList, resultOtoList, secondSaveOtoList, options);
 }
 
 QString ToolDialogAdapter::getToolName() const
 {
-    return metaObject()->className();
+    return {};
 }
 
-void ToolDialogAdapter::setOptionWidget(ToolOptionWidget* value)
+std::unique_ptr<OtoListModifyWorker> ToolDialogAdapter::getWorkerInstance() const
 {
-    optionWidget = value;
+    return std::unique_ptr<OtoListModifyWorker>(qobject_cast<OtoListModifyWorker*>(workerMetaObj.newInstance()));
 }
 
-OtoListModifyWorker* ToolDialogAdapter::getWorker() const
+void ToolDialogAdapter::setWorkerMetaObj(const QMetaObject& value)
 {
-    return worker;
+    workerMetaObj = value;
 }
 
-void ToolDialogAdapter::setWorker(OtoListModifyWorker* value)
+QMetaObject ToolDialogAdapter::getWorkerMetaObj() const
 {
-    worker = value;
+    return workerMetaObj;
 }
+
+QMetaObject ToolDialogAdapter::getOptionWidgetMetaObj() const
+{
+    return optionWidgetMetaObj;
+}
+
+void ToolDialogAdapter::setOptionWidgetMetaObj(const QMetaObject& value)
+{
+    optionWidgetMetaObj = value;
+}
+
 
 void ToolDialogAdapter::replaceOptionWidget(QLayout* rootLayout, ToolOptionWidget* newOptionWidget)
 {
-    if (optionWidget != newOptionWidget)
-        optionWidget = newOptionWidget;
     auto optionLayout = rootLayout->parentWidget()->findChild<QLayout*>("optionLayout");
     Misc::replaceWidget(optionLayout, "optionWidget", newOptionWidget, rootLayout->parentWidget());
 }

--- a/src/toolBase/tooldialogadapter.cpp
+++ b/src/toolBase/tooldialogadapter.cpp
@@ -19,7 +19,7 @@ ToolDialogAdapter::ToolDialogAdapter(QObject *parent) : QObject(parent)
 void ToolDialogAdapter::replaceUIWidgets(QLayout* rootLayout)
 {
     Q_ASSERT_X(optionWidget, "setupSpecificUIWidgets", "OptionWidget is not set.");
-    optionWidget->setOptions(OptionContainer{});
+    optionWidget->setOptions({});
     optionWidget->setParent(rootLayout->parentWidget());
     replaceOptionWidget(rootLayout, optionWidget);
 }

--- a/src/toolBase/tooldialogadapter.h
+++ b/src/toolBase/tooldialogadapter.h
@@ -21,19 +21,20 @@ public:
                         const OptionContainer& options);
     virtual QString getToolName() const;
 
+    QMetaObject getOptionWidgetMetaObj() const;
+    QMetaObject getWorkerMetaObj() const;
+
 protected:
-    void replaceOptionWidget(QLayout* rootLayout, ToolOptionWidget* newOptionWidget);
-    void replaceSaveWidget(QLayout* rootLayout, OtoFileSaveWidget* newSaveWidget);
-    OtoListModifyWorker* getWorker() const;
-    void setWorker(OtoListModifyWorker* value);
-    void setOptionWidget(ToolOptionWidget* value);
+    static void replaceOptionWidget(QLayout* rootLayout, ToolOptionWidget* newOptionWidget);
+    static void replaceSaveWidget(QLayout* rootLayout, OtoFileSaveWidget* newSaveWidget);
+    void setOptionWidgetMetaObj(const QMetaObject& value);
+    void setWorkerMetaObj(const QMetaObject& value);
+private:
+    QMetaObject optionWidgetMetaObj;
+    QMetaObject workerMetaObj;
+    std::unique_ptr<OtoListModifyWorker> getWorkerInstance() const;
 
-    private:
-        QPointer<OtoListModifyWorker> worker = nullptr;
-    QPointer<ToolOptionWidget> optionWidget = nullptr;
 signals:
-
-    friend class Tool;
 };
 
 #endif // TOOLDIALOGADAPTER_H

--- a/src/toolBase/tooldialogadapter.h
+++ b/src/toolBase/tooldialogadapter.h
@@ -28,9 +28,6 @@ protected:
     void setWorker(OtoListModifyWorker* value);
     void setOptionWidget(ToolOptionWidget* value);
 
-
-
-
     private:
         QPointer<OtoListModifyWorker> worker = nullptr;
     QPointer<ToolOptionWidget> optionWidget = nullptr;

--- a/src/toolBase/toolmanager.cpp
+++ b/src/toolBase/toolmanager.cpp
@@ -81,7 +81,7 @@ Tool::Tool(QPointer<ToolDialogAdapter> dialogAdapter, QPointer<OtoListModifyWork
         if (!optionWidget)
         {
             this->optionWidget = dialogAdapter->optionWidget;
-            //Q_ASSERT(this->optionWidget); //As adapater may replace widgets when constructing, this asset has been disabled.
+            Q_ASSERT(this->optionWidget);
         }
     }
 }

--- a/src/toolBase/toolmanager.cpp
+++ b/src/toolBase/toolmanager.cpp
@@ -10,18 +10,8 @@ ToolManager* ToolManager::getManager()
     return manager;
 }
 
-void ToolManager::registerTool(const QString& group, ToolDialogAdapter* dialogAdapter, OtoListModifyWorker* modifyWorker, ToolOptionWidget* optionWidget, QString name)
-{
-    Tool tool{dialogAdapter, modifyWorker, optionWidget, name};
-    registerTool(group, tool);
-}
-
 void ToolManager::registerTool(const QString& group, const Tool& tool)
 {
-    if (!tool.getDialogAdapter())
-        tool.getModifyWorker()->setParent(this);
-    else
-        tool.getDialogAdapter()->setParent(this);
     tools.append(tool);
     toolGroups.insert(group, tool);
     if (!toolGroupNames.contains(group))
@@ -60,46 +50,5 @@ QStringList ToolManager::getToolGroupNamesInRegisterOrder() const
     return toolGroupNames;
 }
 
+
 ToolManager* ToolManager::manager = new ToolManager();
-
-
-Tool::Tool(QPointer<ToolDialogAdapter> dialogAdapter, QPointer<OtoListModifyWorker> modifyWorker, QPointer<ToolOptionWidget> optionWidget, const QString& name)
-    : modifyWorker(modifyWorker), dialogAdapter(dialogAdapter), optionWidget(optionWidget), name((name)) {
-    if (dialogAdapter){
-        if (name.isEmpty())
-        {
-            if (!dialogAdapter->getToolName().isEmpty())
-                this->name = dialogAdapter->getToolName();
-            else {
-                this->name = modifyWorker->metaObject()->className();
-            }
-        }
-        if (!modifyWorker){
-            this->modifyWorker = dialogAdapter->worker;
-            Q_ASSERT(this->modifyWorker);
-        }
-        if (!optionWidget)
-        {
-            this->optionWidget = dialogAdapter->optionWidget;
-            Q_ASSERT(this->optionWidget);
-        }
-    }
-}
-
-
-Tool Tool::makeNewInstance(QObject* parent, QWidget* optionWidgetParent, const QString& nameModifier) const{
-    OtoListModifyWorker* modifyWorkerNew = nullptr;
-    ToolDialogAdapter* dialogAdapterNew = nullptr;
-    ToolOptionWidget* optionWidgetNew = nullptr;
-
-    if (dialogAdapter)
-        dialogAdapterNew = qobject_cast<ToolDialogAdapter*>(dialogAdapter->metaObject()->newInstance(Q_ARG(QObject*, parent)));
-    else
-    {
-        if (modifyWorker)
-            modifyWorkerNew = qobject_cast<OtoListModifyWorker*>(modifyWorker->metaObject()->newInstance(Q_ARG(QObject*, parent)));
-        if (optionWidget)
-            optionWidgetNew = qobject_cast<ToolOptionWidget*>(optionWidget->metaObject()->newInstance(Q_ARG(QWidget*, optionWidgetParent)));
-    }
-    return Tool{dialogAdapterNew, modifyWorkerNew, optionWidgetNew, nameModifier.arg(name)};
-}

--- a/src/toolBase/tooloptionwidget.cpp
+++ b/src/toolBase/tooloptionwidget.cpp
@@ -10,7 +10,7 @@ ToolOptionWidget::ToolOptionWidget(QWidget *parent) : QWidget(parent)
 OptionContainer ToolOptionWidget::getOptions() const
 {
     Q_UNREACHABLE();
-    return OptionContainer{};
+    return {};
 }
 
 void ToolOptionWidget::setOptions(const OptionContainer& options)
@@ -32,7 +32,7 @@ EmptyToolOptionWidget::EmptyToolOptionWidget(QWidget* parent) : ToolOptionWidget
 
 OptionContainer EmptyToolOptionWidget::getOptions() const
 {
-    return OptionContainer{};
+    return {};
 }
 
 void EmptyToolOptionWidget::setOptions(const OptionContainer& options)

--- a/src/utils/misc/fplusAdapter.h
+++ b/src/utils/misc/fplusAdapter.h
@@ -1,17 +1,39 @@
 #ifndef FPLUSADAPTER_H
 #define FPLUSADAPTER_H
 #include <QList>
+#include <fplus/fplus.hpp>
+
+// This file contains some utils that adapt Qt's container to FunctionalPlus.
+// It only contains needed adapters to solve the problem I found, so it is very incomplete.
 
 namespace fplus {
-    template <typename ValueType>
-    QList<ValueType> concat(const QList<QList<ValueType>>& lists)
-    {
-        QList<ValueType> result;
+    template <typename ContainerIn, typename ContainerOut = typename ContainerIn::value_type>
+    ContainerOut concat_qt_adapt_internal(const ContainerIn& lists){
+        ContainerOut result;
         for (auto i : lists){
             result.append(i);
         }
         return result;
     }
+    template <typename ValueType>
+    QList<ValueType> concat(const QList<QList<ValueType>>& lists)
+    {
+        return concat_qt_adapt_internal(lists);
+    }
+    template <typename ValueType>
+    QVector<ValueType> concat(const QVector<QVector<ValueType>>& lists)
+    {
+        return concat_qt_adapt_internal(lists);
+    }
+
+    namespace internal {
+        template<class T> struct has_order<QVector<T>> : public std::true_type{};
+        template<class T> struct has_order<QList<T>> : public std::true_type{};
+
+        template<class T, class NewT, int SizeOffset> struct same_cont_new_t<QVector<T>, NewT, SizeOffset>{typedef class QVector<NewT> type;};
+        template<class T, class NewT, int SizeOffset> struct same_cont_new_t<QList<T>, NewT, SizeOffset>{typedef class QList<NewT> type;};
+    }
+
 }
 
 #endif // FPLUSADAPTER_H

--- a/src/utils/models/otolistshowvaluechangemodel.cpp
+++ b/src/utils/models/otolistshowvaluechangemodel.cpp
@@ -99,10 +99,10 @@ QVariant OtoListShowValueChangeModel::data(const QModelIndex &index, int role) c
                 if (!fonts.isEmpty())
                     fonts.last().setItalic(true);
                 auto bold = []() -> QFont{
-                        QFont font{};
-                        font.setBold(true);
-                        return font;
-            }();
+                    QFont font{};
+                    font.setBold(true);
+                    return font;
+                }();
                 fonts.append(bold);
             }
             else
@@ -157,4 +157,5 @@ void OtoListShowValueChangeModel::refreshHeaderList()
             headerList.append(QString("新的%1").arg(currentName));
     }
 }
+
 

--- a/src/utils/widgets/otofilemultipleloadwidget.cpp
+++ b/src/utils/widgets/otofilemultipleloadwidget.cpp
@@ -98,6 +98,9 @@ void OtoFileMultipleLoadWidget::appendOtoFile()
 
     ui->openFileNameEdit->setFileName("");
     refreshButtonEnableState();
+
+    constexpr auto COLUMN_OTO_FILENAME = 0;
+    ui->otoFileTableView->resizeColumnToContents(COLUMN_OTO_FILENAME);
 }
 
 void OtoFileMultipleLoadWidget::removeOtoFile()


### PR DESCRIPTION
# 行为改进

- 批量打开模式下，加载新的oto文件后，oto文件表格的路径页将会自适应oto.ini路径的长度
- Reset（重置）按钮现在也会重置保存选项

# Bug修复

- 修正“CV/VC部分离”工具无法在“进行多个操作”工具中显示选项的问题

# 架构修整

- 现在所有工具实例将从单例模式变为动态创建